### PR TITLE
Support for getting username from Twitter widget

### DIFF
--- a/content.js
+++ b/content.js
@@ -29,7 +29,16 @@ function extractTwitterUsernames() {
         return;
       }
     });
-    }
+    $("iframe[id*='twitter-widget-']").each(function(iframe) {
+      var widgetId = this.dataset.widgetId;
+
+      var profileMatch = widgetId.match(/profile:(\w*)/);
+      if (profileMatch !== null && profileMatch[1] !== "") {
+        result.push(profileMatch[1]);
+        return;
+      }
+    });
+  }
 
   return result.map(function(i) { return i.toLowerCase(); }).filter(function(item, i, ar) { return ar.indexOf(item) === i; });
 }

--- a/content.js
+++ b/content.js
@@ -12,19 +12,19 @@ function extractTwitterUsernames() {
       var url = this.href;
   
       var usernameMatch = url.match(/twitter.com\/(?:@){0,1}(\w*)/)
-      if (usernameMatch !== null && !["intent", "search", "share", "home"].includes(usernameMatch[1])) {
+      if (usernameMatch !== null && usernameMatch[1] !== "" && !["intent", "search", "share", "home"].includes(usernameMatch[1])) {
         result.push(usernameMatch[1]);
         return;
       }
   
       var viaMatch = url.match(/via[%20@|=](\w*)/);
-      if (viaMatch !== null) {
+      if (viaMatch !== null && viaMatch[1] !== "") {
         result.push(viaMatch[1]);
         return;
       }
   
       var screenNameMatch = url.match(/screen_name=(\w*)/);
-      if (screenNameMatch !== null) {
+      if (screenNameMatch !== null && screenNameMatch[1] !== "") {
         result.push(screenNameMatch[1]);
         return;
       }


### PR DESCRIPTION
Support for getting profile names from embedded Twitter widgets. A can add code like this:

```html
<a class="twitter-timeline" ... href="https://twitter.com/scottsauber" href="https://twitter.com/scottsauber">My Tweets</a>
```

Which replaces the `a` element with this:

```html
<iframe id="twitter-widget-0" ... data-widget-id="profile:scottsauber" title="Twitter Timeline">...</iframe>
```